### PR TITLE
Support for PHP 8.0

### DIFF
--- a/include/classes/editors/class-vc-frontend-editor.php
+++ b/include/classes/editors/class-vc-frontend-editor.php
@@ -643,7 +643,7 @@ class Vc_Frontend_Editor implements Vc_Editor_Interface {
 		$protocol = substr( $sp, 0, strpos( $sp, '/' ) ) . ( ( $ssl ) ? 's' : '' );
 		$port = $s['SERVER_PORT'];
 		$port = ( ( ! $ssl && '80' === $port ) || ( $ssl && '443' === $port ) ) ? '' : ':' . $port;
-		$host = isset( $s['HTTP_X_FORWARDED_HOST'] ) ? $s['HTTP_X_FORWARDED_HOST'] : isset( $s['HTTP_HOST'] ) ? $s['HTTP_HOST'] : $s['SERVER_NAME'];
+		$host = isset( $s['HTTP_X_FORWARDED_HOST'] ) ? $s['HTTP_X_FORWARDED_HOST'] : ( isset( $s['HTTP_HOST'] ) ? $s['HTTP_HOST'] : $s['SERVER_NAME'] );
 
 		return $protocol . '://' . $host . $port . $s['REQUEST_URI'];
 	}


### PR DESCRIPTION
Fixes the following issue

PHP 8.0 compatibility states:
- Nested ternaries now require explicit parentheses.

More info on PHP 7.4->8.0 compatibility:
https://www.php.net/manual/en/migration80.incompatible.php